### PR TITLE
Revert to .net 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: 9.0.x
     - name: Format check
       run: dotnet format --verify-no-changes --verbosity normal
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: 9.0.x
       - name: Publish
         run: dotnet publish src/wshcmx -r linux-x64 -c Release -o ./publish
       - name: Create ZIP

--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ dotnet build
 
 ```bash
 dotnet build src/wshcmx
-dotnet run --project src/Typifier -- --assembly src/wshcmx/bin/Debug/net10.0/wshcmx.dll --output types/wshcmx.d.ts
+dotnet run --project src/Typifier -- --assembly src/wshcmx/bin/Debug/net6.0/wshcmx.dll --output types/wshcmx.d.ts
 ```

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Typifier/Typifier.csproj
+++ b/src/Typifier/Typifier.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Typifier</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/wshcmx/wshcmx.csproj
+++ b/src/wshcmx/wshcmx.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>1.1.0</Version>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>wshcmx</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
# Описание изменений
- Откат на версию .net 6.0 по причине ошибок с 10 версией при работе с WebTutor.
